### PR TITLE
New SystemHeat exponents

### DIFF
--- a/GameData/TweakScale/patches/000_Support/SystemHeat.cfg
+++ b/GameData/TweakScale/patches/000_Support/SystemHeat.cfg
@@ -60,3 +60,12 @@ TWEAKSCALEEXPONENTS:NEEDS[SystemHeat]
 	name = ModuleSystemHeatHarvester
  	systemPower = 3 // scale waste heat with ModuleResourceHarvester speed & power
 }
+
+// https://github.com/post-kerbin-mining-corporation/SystemHeat/blob/master/SystemHeat/SystemHeat/Modules/ModuleSystemHeatSink.cs
+TWEAKSCALEEXPONENTS:NEEDS[SystemHeat]
+{
+	name = ModuleSystemHeatSink
+	heatStorageMass = 3
+	heatStorageMaximum = 3
+ 	maxHeatRate = 2.5 // 2 if heat enters through the surface; higher with internal channels for fluid but 3 seems unlikely?
+}

--- a/GameData/TweakScale/patches/000_Support/SystemHeat.cfg
+++ b/GameData/TweakScale/patches/000_Support/SystemHeat.cfg
@@ -41,6 +41,7 @@ TWEAKSCALEEXPONENTS:NEEDS[SystemHeat]
 {
 	name = ModuleSystemHeatFissionEngine
  	HeatGeneration = 2.5 // scale waste heat with thrust
+  	ElectricalGeneration = 2.5 // and scale electricity generation (engine reactor is larger)
   	// TODO: scale INPUT_RESOURCE{ Ratio} and OUTPUT_RESOURCE{ Ratio} somehow
 }
 

--- a/GameData/TweakScale/patches/000_Support/SystemHeat.cfg
+++ b/GameData/TweakScale/patches/000_Support/SystemHeat.cfg
@@ -14,3 +14,48 @@ TWEAKSCALEEXPONENTS:NEEDS[SystemHeat]
 	// this drives the radiativeFlux, i.e. blackbody radiation, and should be proportional to surface area
 	temperatureCurve = 2
 }
+
+// https://github.com/post-kerbin-mining-corporation/SystemHeat/blob/master/SystemHeat/SystemHeat/Modules/ModuleSystemHeatAsteroidHarvester.cs
+TWEAKSCALEEXPONENTS:NEEDS[SystemHeat]
+{
+	name = ModuleSystemHeatAsteroidHarvester
+ 	systemPower = 3 // scale waste heat with ModuleAsteroidDrill speed & power
+}
+
+// https://github.com/post-kerbin-mining-corporation/SystemHeat/blob/master/SystemHeat/SystemHeat/Modules/ModuleSystemHeatConverter.cs
+TWEAKSCALEEXPONENTS:NEEDS[SystemHeat]
+{
+	name = ModuleSystemHeatConverter
+ 	systemPower = 3 // scale waste heat with ModuleResourceConverter resource lists
+}
+
+// https://github.com/post-kerbin-mining-corporation/SystemHeat/blob/master/SystemHeat/SystemHeat/Modules/ModuleSystemHeatEngine.cs
+TWEAKSCALEEXPONENTS:NEEDS[SystemHeat]
+{
+	name = ModuleSystemHeatEngine
+ 	systemPower = 2.5 // scale waste heat with thrust
+}
+
+// https://github.com/post-kerbin-mining-corporation/SystemHeat/blob/master/SystemHeat/SystemHeat/Modules/ModuleSystemHeatFissionEngine.cs
+TWEAKSCALEEXPONENTS:NEEDS[SystemHeat]
+{
+	name = ModuleSystemHeatFissionEngine
+ 	HeatGeneration = 2.5 // scale waste heat with thrust
+  	// TODO: scale INPUT_RESOURCE{ Ratio} and OUTPUT_RESOURCE{ Ratio} somehow
+}
+
+// https://github.com/post-kerbin-mining-corporation/SystemHeat/blob/master/SystemHeat/SystemHeat/Modules/ModuleSystemHeatFissionReactor.cs
+TWEAKSCALEEXPONENTS:NEEDS[SystemHeat]
+{
+	name = ModuleSystemHeatFissionReactor
+ 	ElectricalGeneration = 3 // as per NearFutureElectrical.cfg's FissionGenerator
+  	HeatGeneration = 3 // scale waste heat with power
+  	// TODO: scale INPUT_RESOURCE{ Ratio} and OUTPUT_RESOURCE{ Ratio} somehow
+}
+
+// https://github.com/post-kerbin-mining-corporation/SystemHeat/blob/master/SystemHeat/SystemHeat/Modules/ModuleSystemHeatHarvester.cs
+TWEAKSCALEEXPONENTS:NEEDS[SystemHeat]
+{
+	name = ModuleSystemHeatHarvester
+ 	systemPower = 3 // scale waste heat with ModuleResourceHarvester speed & power
+}


### PR DESCRIPTION
Should be working? Please double-check, but I've been using these on my install without issue.

For context on the TODO lines, please read https://github.com/TweakScale/Companion_Frameworks/issues/7: I haven't been able to scale reactor inputs and outputs (including using `inputList` like your ModuleResourceHarvester does [here](https://github.com/JonnyOThan/TweakScale/blob/abb20448379cb8450268d54515f8b98901ae3f52/GameData/TweakScale/ScaleExponents.cfg#L209-L218), and `inputResources` like ModuleGenerator does [here](https://github.com/JonnyOThan/TweakScale/blob/abb20448379cb8450268d54515f8b98901ae3f52/GameData/TweakScale/ScaleExponents.cfg#L105-L117)). The `Ratio` in the SystemHeat reactor definition seems to be a direct units-per-second rate of fuel consumption, unrelated to anything about stock generators.

Should I open a new issue here for that? Nothing special in the logs in any case except for "No valid member found" (as in the linked issue) when attempting to target `INPUT_RESOURCE` or `inputList` (but `inputResources` doesn't spit out anything).